### PR TITLE
Add graphql endpoint to server

### DIFF
--- a/backend/graphql/databaseQuery.js
+++ b/backend/graphql/databaseQuery.js
@@ -1,0 +1,26 @@
+const ConnectionData = require('../model/data')
+
+async function getConnectionByProvider({ provider }) {
+    let results = [];
+
+    const query = new Promise((resolve, reject) => {
+        ConnectionData.find().where({ provider: provider }).then((res, err) => {
+            if (err) {
+                reject(err);
+            }
+
+            if (res) {
+                resolve(res)
+            }
+        });
+    });
+
+    return query.then((entry) => {
+        entry.forEach((result) => {
+            results.push(result);
+        });
+        return results;
+    });
+}
+
+module.exports = getConnectionByProvider;

--- a/backend/graphql/databaseQuery.js
+++ b/backend/graphql/databaseQuery.js
@@ -1,4 +1,7 @@
 const ConnectionData = require('../model/data')
+const uuid = require("uuid/v4");
+const logger = require('./../logging');
+
 
 async function getConnectionByProvider({ provider }) {
     let results = [];
@@ -23,4 +26,27 @@ async function getConnectionByProvider({ provider }) {
     });
 }
 
-module.exports = getConnectionByProvider;
+async function createConnectionData({ location, signal, provider }) {
+    const query = new Promise( (resolve, reject) => {
+
+        ConnectionData.create({
+            id: uuid(),
+            signal: signal,
+            location: location,
+            provider: provider,
+        }, (err, result) => {
+            if (err) {
+                reject(err);
+            }
+            if (result) {
+                logger.info('Data successfully stored')
+                resolve(result);
+            }
+        });
+    });
+
+    return query.then( (result) => result)
+                .catch( (error) => logger.error(error))
+}
+
+module.exports = { getConnectionByProvider, createConnectionData };

--- a/backend/graphql/schema.js
+++ b/backend/graphql/schema.js
@@ -17,6 +17,15 @@ const schema = buildSchema(`
         x: Float
         y: Float
     }
+
+    input LocationInput {
+        x: Float!
+        y: Float!
+    }
+
+    type Mutation {
+        createConnectionData(location: LocationInput!, signal: Float!, provider: String!): ConnectionInformation
+    }
 `);
 
 module.exports = schema;

--- a/backend/graphql/schema.js
+++ b/backend/graphql/schema.js
@@ -1,0 +1,22 @@
+const { buildSchema } = require("graphql");
+
+const schema = buildSchema(`
+    type Query {
+        connectionData: [ConnectionInformation]
+        connectionDataByProvider(provider: String): [ConnectionInformation]
+    }
+
+    type ConnectionInformation {
+        id: String
+        location: Location
+        signal: Float
+        provider: String
+    }
+
+    type Location {
+        x: Float
+        y: Float
+    }
+`);
+
+module.exports = schema;

--- a/backend/index.js
+++ b/backend/index.js
@@ -2,7 +2,7 @@ const express = require('express');
 const expressGraphql = require('express-graphql');
 const schema = require('./graphql/schema');
 
-const getConnectionByProvider = require('./graphql/databaseQuery');
+const { getConnectionByProvider, createConnectionData } = require('./graphql/databaseQuery');
 
 const logger = require('./logging');
 const mongoose = require('mongoose');
@@ -15,9 +15,10 @@ mongoose.connect("mongodb://localhost:27017/database").catch(err => {
 
 const ConnectionData = require('./model/data');
 
-const rootQuery = {
+const root = {
     connectionData: () => ConnectionData.find(),
     connectionDataByProvider: getConnectionByProvider,
+    createConnectionData: createConnectionData,
 }
 
 
@@ -26,7 +27,7 @@ require('./mock').mockData();
 const app = express();
 app.use('/graphql', expressGraphql({
     schema: schema,
-    rootValue: rootQuery,
+    rootValue: root,
     graphiql: true,
 }));
 

--- a/backend/index.js
+++ b/backend/index.js
@@ -1,0 +1,56 @@
+const express = require('express');
+const expressGraphql = require('express-graphql');
+const { buildSchema } = require('graphql');
+
+const getConnectionByProvider = require('./graphql/databaseQuery');
+
+const logger = require('./logging');
+const mongoose = require('mongoose');
+
+mongoose.connect("mongodb://localhost:27017/database").catch(err => {
+    if (err) {
+        logger.error(`Database error: ${err}`);
+    }
+});
+
+const ConnectionData = require('./model/data');
+
+const schema = buildSchema(`
+    type Query {
+        connectionData: [ConnectionInformation]
+        connectionDataByProvider(provider: String): [ConnectionInformation]
+    }
+
+    type ConnectionInformation {
+        id: String
+        location: Location
+        signal: Float
+        provider: String
+    }
+
+    type Location {
+        x: Float
+        y: Float
+    }
+`);
+
+
+const rootQuery = {
+    connectionData: () => ConnectionData.find(),
+    connectionDataByProvider: getConnectionByProvider,
+}
+
+
+require('./mock').mockData();
+
+const app = express();
+app.use('/graphql', expressGraphql({
+    schema: schema,
+    rootValue: rootQuery,
+    graphiql: true,
+}));
+
+const port = 5000;
+app.listen(port, () => {
+    logger.info(`express graphql server is running on localhost:${port}/graphql`)
+})

--- a/backend/index.js
+++ b/backend/index.js
@@ -1,6 +1,6 @@
 const express = require('express');
 const expressGraphql = require('express-graphql');
-const { buildSchema } = require('graphql');
+const schema = require('./graphql/schema');
 
 const getConnectionByProvider = require('./graphql/databaseQuery');
 
@@ -14,26 +14,6 @@ mongoose.connect("mongodb://localhost:27017/database").catch(err => {
 });
 
 const ConnectionData = require('./model/data');
-
-const schema = buildSchema(`
-    type Query {
-        connectionData: [ConnectionInformation]
-        connectionDataByProvider(provider: String): [ConnectionInformation]
-    }
-
-    type ConnectionInformation {
-        id: String
-        location: Location
-        signal: Float
-        provider: String
-    }
-
-    type Location {
-        x: Float
-        y: Float
-    }
-`);
-
 
 const rootQuery = {
     connectionData: () => ConnectionData.find(),

--- a/backend/logging/index.js
+++ b/backend/logging/index.js
@@ -1,0 +1,18 @@
+const { createLogger, format, config, transports} = require('winston');
+const { combine, timestamp, printf } = format;
+
+const consoleOutFormat = printf ( ({ level, message, timestamp }) => {
+    return `${timestamp} [${level}] ${message}`
+})
+
+const logger = createLogger({
+    levels: config.syslog.levels,
+
+    format: combine(format.colorize(), timestamp(), consoleOutFormat),
+
+    transports: [
+        new transports.Console(),
+    ],
+});
+
+module.exports = logger;

--- a/backend/logging/index.js
+++ b/backend/logging/index.js
@@ -7,9 +7,7 @@ const consoleOutFormat = printf ( ({ level, message, timestamp }) => {
 
 const logger = createLogger({
     levels: config.syslog.levels,
-
     format: combine(format.colorize(), timestamp(), consoleOutFormat),
-
     transports: [
         new transports.Console(),
     ],

--- a/backend/mock/index.js
+++ b/backend/mock/index.js
@@ -1,0 +1,49 @@
+const ConnectionData = require('./../model/data');
+const uuid = require("uuid/v4");
+const logger = require('./../logging')
+
+module.exports.mockData = () => {
+    ConnectionData.deleteMany((err) => {
+        if (err) {
+            logger.error('Error while deleting', err)
+            return
+        }
+        logger.info("Database content removed for initialization...")
+    });
+
+    const data = [
+        {
+            id: uuid(),
+            location: { x: 54.3227, y: 10.1360 },
+            signal: 85.3,
+            provider: 'Telekom'
+        },
+        {
+            id: uuid(),
+            location: { x: 54.32606, y: 10.13556 },
+            signal: 10.101,
+            provider: 'Vodaphone'
+        },
+        {
+            id: uuid(),
+            location: { x: 54.3204, y: 10.1415 },
+            signal: 99.13,
+            provider: 'O2'
+        },
+        {
+            id: uuid(),
+            location: { x: 54.3196, y: 10.1378 },
+            signal: 35.5,
+            provider: 'Telekom'
+        }
+    ];
+
+    ConnectionData.insertMany(data).then((data, err) => {
+        if (err) {
+            logger.error(err)
+            return
+        } else {
+            logger.info('Data successfully mocked');
+        }
+    });
+}

--- a/backend/model/data.js
+++ b/backend/model/data.js
@@ -1,0 +1,15 @@
+const mongoose = require('mongoose');
+
+const locationSchema = new mongoose.Schema({
+    x: Number,
+    y: Number,
+})
+
+const connectionDataSchema = new mongoose.Schema({
+    id: String,
+    location: locationSchema,
+    signal: Number,
+    provider: String
+})
+
+module.exports = mongoose.model('ConnectionData', connectionDataSchema);

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "mobilereceptionatlas",
+  "version": "1.0.0",
+  "description": "the server backend",
+  "main": "index.js",
+  "scripts": {
+    "start": "nodemon index.js",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/karsil/MobileReceptionAtlas.git"
+  },
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/karsil/MobileReceptionAtlas/issues"
+  },
+  "homepage": "https://github.com/karsil/MobileReceptionAtlas#readme",
+  "dependencies": {
+    "express": "~4.16.4",
+    "express-graphql": "^0.7.1",
+    "graphql": "^14.1.1",
+    "mongoose": "^5.4.7",
+    "nodemon": "^1.18.9",
+    "uuid": "^3.3.2",
+    "winston": "^3.2.1"
+  }
+}


### PR DESCRIPTION
### GraphQL endpoint on server
Sets up a _nodejs_ server with express router and a GraphQl endpoint. 


**done** 
* graphql
  * query schema
  * mutation schema
  * graphiql on `localhost:5000/graphql`

* logging
* mongoose
  * connection between graphql-query and mongodb
  * mongodb schema for connection datatype
